### PR TITLE
feat: work hours options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ parameters are configured via environment variables.
 | ORGANIZATIONS                                      | A comma seperated strings of organizations you want to watch         defaults to empty string  | String               |
 | PERSONAL                                           | Whether to watch personal repos                                       defaults to false        | Boolean              |
 | CONFIG_PATH                                        | The folder containing the configuration files such as mappings.json defaults to ./             | String               |
+| WORK_START                                        | Sets a custom work starting time, bot will not be active before this (ex: 8 = 8AM) defaults to 9             | Integer               |
+| WORK_END                                        | Sets a custom work end time, bot will not be active before this (ex: 18 = 6PM) defaults to 17             | Integer               |
+
 
 
 ### Mappings file

--- a/index.js
+++ b/index.js
@@ -42,8 +42,6 @@ const Slack    = new(require('./lib/slack'))({
 	mappings: slackGithubUsersMappings
 }, Log)
 
-
-
 function pollAndNotify(){
     var now = new Date();
     var hours = now.getHours();

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ var regex			= new RegExp(process.env['REPOS_REGEX'] || '.*');
 var interval		= parseFloat(process.env['INTERVAL']) || 2;
 var organizations   = process.env['ORGANIZATIONS'];
 var personal		= process.env['PERSONAL'];
-var workStart		= process.env['WORK_START'];
-var workEnd			= process.env['WORK_END'];
+var workStart		= process.env['WORK_START'] || 9;
+var workEnd			= process.env['WORK_END'] || 17;
 
 personal = personal && personal.toLowerCase() === 'true' ? true : false;
 organizations = organizations && organizations.length > 0 ? organizations.split(',') : [];


### PR DESCRIPTION
### Story
Adds an option to set work hours outside of which the reminder will not go off. Default values of 0900 and 1700 hours if the env variable is not set.

### Testing
Set your local machine's clock outside of the either the specified or default work start and end values. You should see the `'All work and no play makes Jack a dull boy.'` console message.