### PR TITLE
fix(options): need to check if back inside work hours

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ function pollAndNotify(){
                 setTimeout(pollAndNotify, interval * 60 * 60 * 1000);
             } else {
                 console.log('All work and no play makes Jack a dull boy.');
+
+                // Polls every 15 min to check if we're back in work hours
+                setTimeout(pollAndNotify, interval * 60 * 7500);                
             }
         }
     });


### PR DESCRIPTION
### Story
Noticed a bug with the work hours options - if this is running continuously and falls outside of work hours for the first time after it was initialized, it would never restart the poller and notifier properly. This adds a second poller to check if the bot has come back into work hours, and if so, it should start notifications again.

### Testing
Run the reminder continuously for a couple days with work hours defined, it should not fail to restart notifications after the first work day.