### PR TITLE
feat(options): don't remind if change requested

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -147,8 +147,8 @@ github.prototype = {
 							return false;
 
 
-						if(b.state == "APPROVED")
-							return true;
+                        if(b.state == "APPROVED" || b.state == "CHANGES_REQUESTED")
+                            return true;
 
 						if(b.submitted_at < pullRequest.updated_at)
 							return false;


### PR DESCRIPTION
### Story
This feedback came from one of the engineers on my team where I'm using this. He was continuing to be bothered with reminders on a PR he had been requested to review even after he reviewed it and had requested changes of the PR author. This check should stop that from happening.